### PR TITLE
Resolved #iss36

### DIFF
--- a/MotorNotes/View Controllers/HomeViewController.swift
+++ b/MotorNotes/View Controllers/HomeViewController.swift
@@ -44,6 +44,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
     @objc func loadData() {
         
         carArray.removeAll()
+        carDocumentId.removeAll()
         
         db.collection("users").document(Constants.Authentication.user).collection("cars").getDocuments() { (querySnapshot, err) in
             if let err = err {


### PR DESCRIPTION
Resolves #36. When the view gets loaded, the array containing the list of vehicles gets emptied to make room for any changes made in the database. The issue here was that the list of the car's `Document ID` wasn't getting emptied to accommodate database refreshes. Instead, what happened was the list would cycle through only the first loaded instance of the `carDocumentId` array. 

For example, say there were 2 cars on the user's list before adding a new car. When the new car gets added (making it the third car), the list of Document IDs don't get refreshed. When the third car is tapped, it loops back and displays the first car's detailed information instead of the third car's detailed information. 

I suspect that the `TableView` method has a failsafe in which it takes the `indexPath.row` number and performs a modulus on the count for the `carDocumentId` array, thus making the third car tapped actually displaying the first car's information. This is merely speculation on my end on what could've happened.